### PR TITLE
Compatibility with tbl_df from dplyr

### DIFF
--- a/R/ez-internal.R
+++ b/R/ez-internal.R
@@ -179,6 +179,9 @@ function(data, dv, wid, within, within_full, within_covariates, between, between
 	if(is.null(within) & is.null(between)){
 		stop('is.null(within) & is.null(between)\nYou must specify at least one independent variable.')
 	}
+	if(inherits(data, "tbl_df")) {
+	  data <- as.data.frame(data)
+	}
 	if(!is.data.frame(data)){
 		stop('"data" must be a data frame.')
 	}


### PR DESCRIPTION
This PR adds compatibility for data frames created with `data_frame` from the dplyr package to the `ezANOVA` function.
Right now, when passing a `tbl_df` as the `data` argument, the function returns the following error:
```
Error in ezANOVA_main(data = data, dv = dv, wid = wid, within = within,  : 
  "dv" must be numeric.
```
This is caused by
```r
if(!is.numeric(data[,names(data)==dv])){
```
(line 185 in `ez-internal.R`)

Whereas `[.data.frame` returns a vector that can be passed to `is.numeric`, `[.tbl_df` retuns a single column data frame that returns `FALSE` on `is.numeric`.

